### PR TITLE
Fix missing invited email in event data

### DIFF
--- a/lib/modules/helper/helper.dart
+++ b/lib/modules/helper/helper.dart
@@ -205,6 +205,9 @@ class Helper extends GetX {
                             // Permitir crear el evento sin invitado
                             userController.deselectUser();
                             calendarController.updateField('owner_id', []);
+                            if (typedEmail.isNotEmpty) {
+                              calendarController.updateField('user_email', typedEmail);
+                            }
                             CustomSnackbar.show(
                               title: 'Aviso',
                               message: 'No se encontró el usuario, el evento se creará sin invitado',
@@ -221,6 +224,9 @@ class Helper extends GetX {
                               final randomUser = userController.users[Random().nextInt(userController.users.length)];
                               calendarController.updateField('owner_id', [randomUser.id]);
                               userController.selectUser(randomUser);
+                            }
+                            if (typedEmail.isNotEmpty) {
+                              calendarController.updateField('user_email', typedEmail);
                             }
                             Navigator.of(context).pop();
                           }


### PR DESCRIPTION
## Summary
- ensure typed invite email is stored in event data when no user is found

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848d6e39c60832da8d3a67aec32b6d0