### PR TITLE
Add professional registration fields

### DIFF
--- a/lib/modules/auth/sign_up/controllers/sign_up_controller.dart
+++ b/lib/modules/auth/sign_up/controllers/sign_up_controller.dart
@@ -21,6 +21,22 @@ class SignUpController extends GetxController {
   TextEditingController password2Cont = TextEditingController();
   TextEditingController userTypeCont = TextEditingController();
   TextEditingController genCont = TextEditingController();
+  TextEditingController certificationNumberCont = TextEditingController();
+  TextEditingController certificationNameCont = TextEditingController();
+  TextEditingController cvNameCont = TextEditingController();
+
+  RxString certificationPath = ''.obs;
+  RxString cvPath = ''.obs;
+  RxBool isProfessional = false.obs;
+
+  void onUserTypeChanged(String? value) {
+    userTypeCont.text = value ?? '';
+    if (value == 'Veterinario' || value == 'Entrenador') {
+      isProfessional.value = true;
+    } else {
+      isProfessional.value = false;
+    }
+  }
 
   Future<void> saveForm() async {
     if (!isAcceptedTc.value) {
@@ -44,7 +60,26 @@ class SignUpController extends GetxController {
         "user_type": mapUserType(userTypeCont.text)
       };
 
-      final value = await AuthServiceApis.createUser(request: req);
+      if (isProfessional.value) {
+        if (certificationPath.value.isEmpty ||
+            certificationNumberCont.text.trim().isEmpty ||
+            cvPath.value.isEmpty) {
+          CustomSnackbar.show(
+            title: 'Campos incompletos',
+            message: 'Complete la información profesional requerida',
+            isError: true,
+          );
+          return;
+        }
+        req['certificate_number'] = certificationNumberCont.text.trim();
+      }
+      final value = isProfessional.value
+          ? await AuthServiceApis.createUserWithFiles(
+              request: req,
+              certificationPath: certificationPath.value,
+              cvPath: cvPath.value,
+            )
+          : await AuthServiceApis.createUser(request: req);
       toast(value.message.toString(), print: true);
 
       var message = mapUserType(userTypeCont.text) != 'user'

--- a/lib/modules/auth/sign_up/screens/signup_screen.dart
+++ b/lib/modules/auth/sign_up/screens/signup_screen.dart
@@ -8,6 +8,7 @@ import 'package:pawlly/components/button_default_widget.dart';
 import 'package:pawlly/components/custom_select_form_field_widget.dart';
 import 'package:pawlly/components/custom_snackbar.dart';
 import 'package:pawlly/components/custom_text_form_field_widget.dart';
+import 'package:pawlly/modules/components/input_text.dart';
 import 'package:pawlly/main.dart';
 import 'package:pawlly/modules/auth/sign_up/controllers/sign_up_controller.dart';
 import 'package:pawlly/routes/app_pages.dart';
@@ -191,8 +192,57 @@ class SignUpScreen extends GetView<SignUpController> {
                                       ? 'Seleccione su género'
                                       : null,
                                 ],
+                                onChange: controller.onUserTypeChanged,
                               ),
                             ),
+                            Obx(() {
+                              if (!controller.isProfessional.value) {
+                                return const SizedBox.shrink();
+                              }
+                              return Column(
+                                children: [
+                                  const SizedBox(height: 16),
+                                  InputText(
+                                    controller: controller.certificationNameCont,
+                                    isFilePicker: true,
+                                    label: 'Certificación (PDF)',
+                                    placeholder: 'Añadir archivo .pdf',
+                                    placeholderSvg:
+                                        'assets/icons/svg/imagen2.svg',
+                                    onChanged: (value) {
+                                      controller.certificationPath.value = value;
+                                    },
+                                  ),
+                                  const SizedBox(height: 16),
+                                  CustomTextFormFieldWidget(
+                                    controller:
+                                        controller.certificationNumberCont,
+                                    placeholder: 'Número Certificado',
+                                    placeholderSvg:
+                                        'assets/icons/svg/profile.svg',
+                                    colorSVG: Color(0xFFFCBA67),
+                                    validators: [
+                                      (value) => controller.isProfessional.value &&
+                                              (value?.isEmpty ?? true)
+                                          ? 'Campo requerido'
+                                          : null,
+                                    ],
+                                  ),
+                                  const SizedBox(height: 16),
+                                  InputText(
+                                    controller: controller.cvNameCont,
+                                    isFilePicker: true,
+                                    label: 'Currículum Vitae (PDF)',
+                                    placeholder: 'Añadir archivo .pdf',
+                                    placeholderSvg:
+                                        'assets/icons/svg/imagen2.svg',
+                                    onChanged: (value) {
+                                      controller.cvPath.value = value;
+                                    },
+                                  ),
+                                ],
+                              );
+                            }),
                             // Aceptar términos y condiciones
                             Column(
                               children: [

--- a/lib/services/auth_service_apis.dart
+++ b/lib/services/auth_service_apis.dart
@@ -31,6 +31,33 @@ class AuthServiceApis extends GetxController {
     return RegUserResp.fromJson(await handleResponse(await buildHttpResponse(APIEndPoints.register, request: request, method: HttpMethodType.POST)));
   }
 
+  static Future<RegUserResp> createUserWithFiles({
+    required Map<String, dynamic> request,
+    required String certificationPath,
+    required String cvPath,
+  }) async {
+    MultipartRequest multiPartRequest =
+        await getMultiPartRequest(APIEndPoints.register);
+
+    multiPartRequest.fields.addAll(await getMultipartFields(val: request));
+    multiPartRequest.files
+        .add(await MultipartFile.fromPath('certification', certificationPath));
+    multiPartRequest.files
+        .add(await MultipartFile.fromPath('curriculum_vitae', cvPath));
+
+    multiPartRequest.headers
+        .addAll(buildHeaderTokens(endPoint: APIEndPoints.register));
+
+    RegUserResp response = RegUserResp(userData: UserData());
+    await sendMultiPartRequest(multiPartRequest, onSuccess: (data) async {
+      response = RegUserResp.fromJson(jsonDecode(data));
+    }, onError: (error) {
+      throw error;
+    });
+
+    return response;
+  }
+
   static Future<void> saveToken(String token) async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
     await prefs.setString('apiToken', token);


### PR DESCRIPTION
## Summary
- extend `SignUpController` with professional registration logic
- show certification and CV fields when the selected role is trainer or vet
- handle file uploads in the backend via new `createUserWithFiles` API

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849f31bcd28832d90ee17b863da977b