### PR TITLE
Add optional PayPal account field

### DIFF
--- a/lib/models/user_data_model.dart
+++ b/lib/models/user_data_model.dart
@@ -16,6 +16,7 @@ class UserData {
   String gender; // Campo "gender" agregado
   bool isNewUser;
   String? deviceToken;
+  String paymentAccount;
   UserData({
     this.id = -1,
     this.firstName = "",
@@ -34,6 +35,7 @@ class UserData {
     this.gender = "", // Inicialización del campo gender
     this.isNewUser = true,
     this.deviceToken,
+    this.paymentAccount = "",
   });
 
   factory UserData.fromJson(Map<String, dynamic> json) {
@@ -61,7 +63,10 @@ class UserData {
         gender: json['gender'] is String
             ? json['gender']
             : "", // Campo gender añadido
-        deviceToken: json['device_token'].toString());
+        deviceToken: json['device_token'].toString(),
+        paymentAccount: json['payment_account'] is String
+            ? json['payment_account']
+            : "");
   }
 
   Map<String, dynamic> toJson() {
@@ -81,6 +86,7 @@ class UserData {
       'is_social_login': isSocialLogin,
       'user_type': userType,
       'gender': gender, // Agregado a la serialización
+      'payment_account': paymentAccount,
     };
   }
 }

--- a/lib/modules/auth/sign_up/controllers/sign_up_controller.dart
+++ b/lib/modules/auth/sign_up/controllers/sign_up_controller.dart
@@ -24,6 +24,7 @@ class SignUpController extends GetxController {
   TextEditingController certificationNumberCont = TextEditingController();
   TextEditingController certificationNameCont = TextEditingController();
   TextEditingController cvNameCont = TextEditingController();
+  TextEditingController paymentAccountCont = TextEditingController();
 
   RxString certificationPath = ''.obs;
   RxString cvPath = ''.obs;
@@ -72,6 +73,9 @@ class SignUpController extends GetxController {
           return;
         }
         req['certificate_number'] = certificationNumberCont.text.trim();
+        if (paymentAccountCont.text.trim().isNotEmpty) {
+          req['payment_account'] = paymentAccountCont.text.trim();
+        }
       }
       final value = isProfessional.value
           ? await AuthServiceApis.createUserWithFiles(

--- a/lib/modules/auth/sign_up/screens/signup_screen.dart
+++ b/lib/modules/auth/sign_up/screens/signup_screen.dart
@@ -202,6 +202,19 @@ class SignUpScreen extends GetView<SignUpController> {
                                       controller.cvPath.value = value;
                                     },
                                   ),
+                                  const SizedBox(height: 16),
+                                  CustomTextFormFieldWidget(
+                                    controller: controller.paymentAccountCont,
+                                    placeholder: 'Cuenta paypal',
+                                    placeholderSvg: 'assets/icons/svg/sms.svg',
+                                    colorSVG: Color(0xFFFCBA67),
+                                    validators: [
+                                      (value) =>
+                                          value!.isNotEmpty && !value.contains('@')
+                                              ? 'Ingrese un correo válido'
+                                              : null,
+                                    ],
+                                  ),
                                 ],
                               );
                             }),

--- a/lib/modules/pet_owner_profile/controllers/owner_model.dart
+++ b/lib/modules/pet_owner_profile/controllers/owner_model.dart
@@ -49,6 +49,7 @@ class UserData {
   String? fullName;
   String? profileImage;
   String? publicProfile;
+  String? paymentAccount;
   Profile? profile;
   List<Pets>? pets;
 
@@ -82,6 +83,7 @@ class UserData {
     this.fullName,
     this.profileImage,
     this.publicProfile,
+    this.paymentAccount,
     this.profile,
     this.pets,
   });
@@ -115,6 +117,7 @@ class UserData {
       fullName: json['full_name'],
       profileImage: json['profile_image'],
       publicProfile: json['public_profile'],
+      paymentAccount: json['payment_account'],
       profile:
           json['profile'] != null ? Profile.fromJson(json['profile']) : null,
       pets: json['pets'] != null
@@ -154,6 +157,7 @@ class UserData {
       'full_name': fullName,
       'profile_image': profileImage,
       'public_profile': publicProfile,
+      'payment_account': paymentAccount,
       'profile': profile?.toJson(),
       'pets': pets != null
           ? List<dynamic>.from(pets!.map((x) => x.toJson()))

--- a/lib/modules/profile/controllers/profile_controller.dart
+++ b/lib/modules/profile/controllers/profile_controller.dart
@@ -94,7 +94,8 @@ class ProfileController extends GetxController {
     'about_self': "",
     'address': "",
     'tags': <String>[], // Lista de cadenas
-    'validation_number': ""
+    'validation_number': "",
+    'payment_account': ""
   };
 
   void addUserTag(Map<String, dynamic> user, String tag) {
@@ -110,6 +111,7 @@ class ProfileController extends GetxController {
     user['gender'] = currentUser.gender;
     user['userType'] = currentUser.userType;
     user['profileImage'] = currentUser.profileImage;
+    user['payment_account'] = currentUser.paymentAccount;
   }
 
   Future<void> updateProfile() async {
@@ -181,6 +183,8 @@ class ProfileController extends GetxController {
               //   currentUser.gender = data['data']['gender'].toLowerCase();
               user['lastName'] = data['data']['last_name'];
               currentUser.lastName = data['data']['last_name'];
+              user['payment_account'] = data['data']['payment_account'];
+              currentUser.paymentAccount = data['data']['payment_account'];
               Get.back();
             },
           ),

--- a/lib/modules/profile/screens/profile_screen.dart
+++ b/lib/modules/profile/screens/profile_screen.dart
@@ -271,6 +271,23 @@ class ProfileScreen extends StatelessWidget {
                             fondoColor: controller.isEditing.value == false ? Colors.white : Styles.fiveColor,
                           );
                         }),
+                        if (AuthServiceApis.dataCurrentUser.userRole[0] != 'user')
+                          Column(
+                            children: [
+                              SizedBox(height: margin),
+                              Obx(() {
+                                return InputText(
+                                  borderColor: Styles.iconColorBack,
+                                  onChanged: (value) => controller.user['payment_account'] = value,
+                                  initialValue: controller.user['payment_account'].toString(),
+                                  placeholder: 'Cuenta paypal',
+                                  placeholderSvg: 'assets/icons/svg/sms.svg',
+                                  readOnly: !controller.isEditing.value,
+                                  fondoColor: controller.isEditing.value == false ? Colors.white : Styles.fiveColor,
+                                );
+                              }),
+                            ],
+                          ),
                         SizedBox(
                           height: margin,
                         ),


### PR DESCRIPTION
## Summary
- allow saving PayPal payment email for trainers and vets
- include payment account in user models
- show/edit PayPal email on signup and profile screens

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a0bc6f358832da3eb2fa8cd87635a