### PR TITLE
Check payment account before withdraw

### DIFF
--- a/lib/modules/fideo_coin/Recarga.dart
+++ b/lib/modules/fideo_coin/Recarga.dart
@@ -9,6 +9,7 @@ import 'package:pawlly/modules/components/style.dart';
 import 'package:pawlly/modules/dashboard/screens/dashboard_screen.dart';
 import 'package:pawlly/modules/fideo_coin/recarga_controller.dart';
 import 'package:pawlly/styles/recursos.dart';
+import 'package:pawlly/services/auth_service_apis.dart';
 
 class RecargarSaldoScreen extends StatefulWidget {
   final bool isWithdraw;
@@ -178,6 +179,16 @@ class _RecargarSaldoScreenState extends State<RecargarSaldoScreen> {
                         CustomSnackbar.show(
                           title: 'Error',
                           message: 'Debe ingresar un monto mayor a 0',
+                          isError: true,
+                        );
+                        return;
+                      }
+
+                      if (widget.isWithdraw &&
+                          AuthServiceApis.dataCurrentUser.paymentAccount.isEmpty) {
+                        CustomSnackbar.show(
+                          title: 'Cuenta de pago requerida',
+                          message: 'Debes agregar una cuenta de pago desde tu perfil',
                           isError: true,
                         );
                         return;

--- a/lib/modules/fideo_coin/recarga_controller.dart
+++ b/lib/modules/fideo_coin/recarga_controller.dart
@@ -57,6 +57,15 @@ class StripeController extends GetxController {
   }
 
   Future<void> withdrawBalance(String amount, BuildContext context) async {
+    if (AuthServiceApis.dataCurrentUser.paymentAccount.isEmpty) {
+      CustomSnackbar.show(
+        title: 'Cuenta de pago requerida',
+        message: 'Debes agregar una cuenta de pago desde tu perfil',
+        isError: true,
+      );
+      return;
+    }
+
     isLoading.value = true;
     try {
       var response = await http.post(


### PR DESCRIPTION
## Summary
- avoid withdraw request if user hasn't set payment email
- show message to add a payment account when needed

## Testing
- `flutter test` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b394801c8832dbf52f440de4ea094