### PR TITLE
Fix Google logout

### DIFF
--- a/lib/modules/auth/sign_in/controllers/sign_in_controller.dart
+++ b/lib/modules/auth/sign_in/controllers/sign_in_controller.dart
@@ -272,6 +272,9 @@ class SignInController extends GetxController {
       // Primero llamar al API de logout
       final result = await AuthServiceApis.logoutApi();
 
+      // Cerrar sesión de Google/Firebase en caso de haber iniciado con ellos
+      await GoogleSignInAuthService.signOutGoogle();
+
       if (result.status) {
         // Si el logout fue exitoso, navegar a WelcomeScreen
         isLoading(false);

--- a/lib/modules/dashboard/controllers/dashboard_controller.dart
+++ b/lib/modules/dashboard/controllers/dashboard_controller.dart
@@ -2,6 +2,7 @@ import 'package:get/get.dart';
 import 'package:pawlly/models/user_data_model.dart';
 import 'package:pawlly/routes/app_pages.dart';
 import 'package:pawlly/services/auth_service_apis.dart';
+import 'package:pawlly/utils/social_logins.dart';
 
 class DashboardController extends GetxController {
   late UserData currentUser;
@@ -22,8 +23,11 @@ class DashboardController extends GetxController {
   }
 
   Future<void> logoutUser() async {
-    // Llama a la función para cerrar sesión
+    // Llama a la función para cerrar sesión en backend
     await AuthServiceApis.logoutApi();
+
+    // Cerrar sesión de Google/Firebase para permitir seleccionar otra cuenta
+    await GoogleSignInAuthService.signOutGoogle();
 
     // Agregar un pequeño retraso antes de redirigir
     Future.delayed(const Duration(milliseconds: 500), () {

--- a/lib/modules/profile/controllers/profile_controller.dart
+++ b/lib/modules/profile/controllers/profile_controller.dart
@@ -10,6 +10,7 @@ import 'package:pawlly/configs.dart';
 import 'package:pawlly/models/user_data_model.dart';
 import 'package:pawlly/modules/pet_owner_profile/controllers/pet_owner_profile_controller.dart';
 import 'package:pawlly/services/auth_service_apis.dart';
+import 'package:pawlly/utils/social_logins.dart';
 
 import '../../auth/sign_in/screens/signin_screen.dart';
 
@@ -261,6 +262,9 @@ class ProfileController extends GetxController {
       if (response.statusCode == 200 || response.statusCode == 201) {
         // Logout the user and clear data
         await AuthServiceApis.logoutApi();
+
+        // Cerrar sesión de Google/Firebase si corresponde
+        await GoogleSignInAuthService.signOutGoogle();
 
         Get.offAll(() => SignInScreen());
 

--- a/lib/utils/social_logins.dart
+++ b/lib/utils/social_logins.dart
@@ -63,6 +63,21 @@ class GoogleSignInAuthService {
     }
   }
 
+  /// Sign out from Firebase and Google to clear any persisted session
+  static Future<void> signOutGoogle() async {
+    try {
+      await googleSignIn.signOut();
+    } catch (e) {
+      log('Google sign out error: $e');
+    }
+
+    try {
+      await auth.signOut();
+    } catch (e) {
+      log('Firebase sign out error: $e');
+    }
+  }
+
   // region Apple Sign
   static Future<UserData> signInWithApple() async {
     if (await TheAppleSignIn.isAvailable()) {


### PR DESCRIPTION
## Summary
- add Google sign-out helper
- sign out of Google on logout from dashboard, profile and sign-in controllers

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c41f54bfc832db81d2d1037ec9429