### PR TITLE
Fix event notification refresh and overflowed date

### DIFF
--- a/lib/modules/integracion/controller/notificaciones/notificaciones_controller.dart
+++ b/lib/modules/integracion/controller/notificaciones/notificaciones_controller.dart
@@ -216,6 +216,7 @@ class NotificationController extends GetxController {
             primaryButtonText: 'Continuar',
             onPrimaryButtonPressed: () {
               Get.back();
+              fetchNotifications();
             },
           ),
           barrierDismissible: true,
@@ -266,6 +267,7 @@ class NotificationController extends GetxController {
             primaryButtonText: 'Continuar',
             onPrimaryButtonPressed: () {
               Get.back();
+              fetchNotifications();
             },
           ),
           barrierDismissible: true,

--- a/lib/modules/profile_pet/screens/widget/information_tab.dart
+++ b/lib/modules/profile_pet/screens/widget/information_tab.dart
@@ -234,13 +234,16 @@ class InformationTab extends StatelessWidget {
                                   style: Styles.textProfile14w400,
                                 ),
                                 const SizedBox(height: 4),
-                                Text(
-                                  Helper.formatDateToSpanish(homeController
-                                          .selectedProfile
-                                          .value!
-                                          .dateOfBirth) ??
-                                      "",
-                                  style: Styles.textProfile14w800,
+                                Flexible(
+                                  child: Text(
+                                    Helper.formatDateToSpanish(homeController
+                                            .selectedProfile
+                                            .value!
+                                            .dateOfBirth) ??
+                                        "",
+                                    style: Styles.textProfile14w800,
+                                    overflow: TextOverflow.ellipsis,
+                                  ),
                                 ),
                               ],
                             ),


### PR DESCRIPTION
## Summary
- refresh notification list after accepting/rejecting events
- ensure long pet birth dates don't overflow

## Testing
- `flutter format lib/modules/integracion/controller/notificaciones/notificaciones_controller.dart lib/modules/profile_pet/screens/widget/information_tab.dart` *(fails: command not found)*
- `dart format lib/modules/integracion/controller/notificaciones/notificaciones_controller.dart lib/modules/profile_pet/screens/widget/information_tab.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c5c151804832db83758fb897c4b27