### PR TITLE
Fix professional assignment label display

### DIFF
--- a/lib/modules/home/screens/profecionales/user_card.dart
+++ b/lib/modules/home/screens/profecionales/user_card.dart
@@ -129,39 +129,6 @@ class UserCard extends StatelessWidget {
                     ],
                   ),
                   const SizedBox(height: 4),
-                  Builder(builder: (context) {
-                    final selectedId = homeController.selectedProfile.value?.id;
-                    final linked = selectedId != null &&
-                        (user.pets?.contains(selectedId) ?? false);
-                    if (!linked) return const SizedBox.shrink();
-                    return Container(
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: 8, vertical: 4),
-                      decoration: BoxDecoration(
-                        color: const Color(0xFFE5FEED),
-                        border: Border.all(color: const Color(0xFF19A02F), width: 0.5),
-                        borderRadius: BorderRadius.circular(16),
-                      ),
-                      child: Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Image.asset('assets/icons/palomiar.png'),
-                          const SizedBox(width: 4),
-                          Text(
-                            user.userType == 'vet'
-                                ? 'Veterinario asignado a tu mascota'
-                                : 'Entrenador asignado a tu mascota',
-                            style: const TextStyle(
-                              color: Color(0xFF19A02F),
-                              fontWeight: FontWeight.bold,
-                              fontFamily: 'lato',
-                              fontSize: 12,
-                            ),
-                          ),
-                        ],
-                      ),
-                    );
-                  }),
                 ],
               ),
             ),

--- a/lib/modules/pet_owner_profile/controllers/pet_owner_profile_controller.dart
+++ b/lib/modules/pet_owner_profile/controllers/pet_owner_profile_controller.dart
@@ -19,7 +19,7 @@ class PetOwnerProfileController extends GetxController {
   var description =
       'Descripción del usuario aquí... Esta es una breve descripción de la persona asociada.'
           .obs;
-  var veterinarianLinked = true.obs; // Condición si está vinculado
+  var veterinarianLinked = false.obs; // Condición si está vinculado
   var specializationArea = 'Cirugía'.obs; // Área de especialización principal
   var otherAreas = ['Cardiología', 'Dermatología', 'Oftalmología']
       .obs; // Lista de otras áreas de especialización


### PR DESCRIPTION
## Summary
- hide assigned professional label in professional list
- default linked flag to false in profile controller

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cabf27a1c832d9d633ed782984334