### PR TITLE
Fix professional status on profile

### DIFF
--- a/lib/modules/home/screens/profecionales/user_card.dart
+++ b/lib/modules/home/screens/profecionales/user_card.dart
@@ -26,8 +26,9 @@ class UserCard extends StatelessWidget {
         profileController
             .fetchUserData('${user.id}'); // Obtener los datos del usuario
         print('perfil usuario ${jsonEncode(profileController.user.value)}');
-          if (users?.id != null) {
-          Get.to(() => PetOwnerProfileScreen(id: '${user.id}'));
+        if (users?.id != null) {
+          Get.to(() =>
+              PetOwnerProfileScreen(id: '${user.id}', pets: user.pets));
         } else {}
       },
       child: Container(

--- a/lib/modules/pet_owner_profile/controllers/pet_owner_profile_controller.dart
+++ b/lib/modules/pet_owner_profile/controllers/pet_owner_profile_controller.dart
@@ -20,6 +20,7 @@ class PetOwnerProfileController extends GetxController {
       'Descripción del usuario aquí... Esta es una breve descripción de la persona asociada.'
           .obs;
   var veterinarianLinked = false.obs; // Condición si está vinculado
+  var veterinarianVerified = false.obs; // Condición si está verificado
   var specializationArea = 'Cirugía'.obs; // Área de especialización principal
   var otherAreas = ['Cardiología', 'Dermatología', 'Oftalmología']
       .obs; // Lista de otras áreas de especialización

--- a/lib/modules/pet_owner_profile/screens/pet_owner_profile.dart
+++ b/lib/modules/pet_owner_profile/screens/pet_owner_profile.dart
@@ -34,13 +34,14 @@ class _PetOwnerProfileScreenState extends State<PetOwnerProfileScreen> {
     super.initState();
     profileController.fetchUserData(widget.id).then((_) {
       final selectedId = homeController.selectedProfile.value?.id;
-      final petIds = profileController.user.value.pets
-              ?.map((e) => e.id)
-              .whereType<int>()
-              .toList() ??
-          [];
+      final petIds = widget.pets ?? [];
       controller.veterinarianLinked.value =
           selectedId != null && petIds.contains(selectedId);
+
+      controller.veterinarianVerified.value =
+          (profileController.user.value.profile?.validationNumber != null &&
+              profileController
+                  .user.value.profile!.validationNumber!.isNotEmpty);
     });
   }
 

--- a/lib/modules/profile/screens/components/veteinari_info.dart
+++ b/lib/modules/profile/screens/components/veteinari_info.dart
@@ -16,7 +16,7 @@ class VeterinarianInfo extends StatelessWidget {
   Widget build(BuildContext context) {
     if (profileController.user.value.userType != 'user') {
       return Obx(() {
-        if (controller.veterinarianLinked.value) {
+        if (controller.veterinarianVerified.value) {
           return Container(
             height: 54,
             width: MediaQuery.sizeOf(context).width,
@@ -37,8 +37,8 @@ class VeterinarianInfo extends StatelessWidget {
                 SizedBox(width: 8),
                 Text(
                   profileController.user.value.userType == 'vet'
-                      ? 'Veterinario Calificado'
-                      : "Entrenador Calificado",
+                      ? 'Veterinario certificado'
+                      : "Entrenador verificado",
                   style: const TextStyle(
                     color: Color(0xFF19A02F),
                     fontWeight: FontWeight.bold,


### PR DESCRIPTION
## Summary
- track professional verification status
- check linked status using incoming pet list
- show `Veterinario certificado` or `Entrenador verificado` accordingly
- pass pet list when opening professional profile

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684caea05ec8832d81a4d5dd7860891a