### PR TITLE
Add task files for TODO cleanup and Pet model review

### DIFF
--- a/.reports/reporte_todo_pet.md
+++ b/.reports/reporte_todo_pet.md
@@ -1,0 +1,90 @@
+# Revisión de TODOs y clases duplicadas
+
+Este documento resume los comentarios `// TODO:` encontrados en `lib/` y los posibles problemas asociados. También se analiza la coexistencia de varias clases `Pet`.
+
+## Lista de TODOs relevantes
+
+1. **PetServiceApis**
+   - Archivo: `lib/services/pet_service_apis.dart`
+   - Línea: 24
+   - Comentario: "Este método no se está utilizando".
+   - Posible impacto: código muerto que puede generar confusión sobre la forma correcta de enviar los detalles de la mascota.
+
+2. **PetsRepository**
+   - Archivo: `lib/repositories/pets_repository.dart`
+   - Línea: 16
+   - Comentario: "Implementar un método para anexar los archivos y conectarlo con el método addPetDetailsApi del servicio".
+   - Posible impacto: actualmente no hay soporte para subir imágenes u otros archivos al crear mascotas desde el repositorio, por lo que cada pantalla debe manejarlo por su cuenta.
+
+3. **Cursos** y **BanerComentarios**
+   - Archivos: `lib/modules/apprenticeship/component/cursos.dart` y `lib/modules/components/baner_comentarios.dart`
+   - Líneas: 22 y 111 respectivamente
+   - Comentario: "implement build".
+   - Posible impacto: son restos de plantillas; no afectan el funcionamiento pero deberían eliminarse para mantener el código limpio.
+
+4. **ProfilePetController**
+   - Archivo: `lib/modules/profile_pet/controllers/profile_pet_controller.dart`
+   - Línea: 167
+   - Comentario: "Verificar cuántos modales están abiertos en este punto".
+   - Posible impacto: si `Get.close(3)` no coincide con la pila real de diálogos, podría cerrarse más (o menos) de lo necesario y provocar estados inesperados en la navegación.
+
+5. **PetPassportForm**
+   - Archivo: `lib/modules/profile_pet/screens/pet_passport_form.dart`
+   - Línea: 32
+   - Comentario: "Revisa los comentarios en la clase PetControllerv2".
+   - Posible impacto: indica que el formulario depende de la lógica de `PetControllerv2`, la cual necesita refactorización.
+
+6. **CursoVideo**
+   - Archivo: `lib/modules/home/screens/explore/show/curso_video.dart`
+   - Línea: 125
+   - Comentario: "Validar el formato recibido en dateCreated".
+   - Posible impacto: si `widget.dateCreated` viene en un formato inesperado, `DateHelper.formatUiDateLongFromString` podría lanzar una excepción y fallar la vista.
+
+7. **Pacientes**
+   - Archivo: `lib/modules/dashboard/screens/pacientes.dart`
+   - Línea: 100
+   - Comentario: "Reemplazar esta forma de inyectar los datos de la mascota".
+   - Posible impacto: pasar toda la instancia de `PetData` por argumentos puede generar problemas de serialización o estados no sincronizados; se sugiere pasar solo el id y cargar la mascota en la vista destino.
+
+8. **HistorialClinicoController**
+   - Archivo: `lib/modules/integracion/controller/historial_clinico/historial_clinico_controller.dart`
+   - Línea: 29
+   - Comentario: "implement onInit".
+   - Posible impacto: el controlador no ejecuta ninguna carga inicial de datos; la vista que lo use podría mostrarse vacía o sin inicializar.
+
+9. **PetControllerv2**
+   - Archivo: `lib/modules/integracion/controller/mascotas/mascotas_controller.dart`
+   - Líneas: 16, 35 y 120
+   - Comentarios: "Ojo con esta clase"; "Verificar, aparentemente este método vuelve a cargar las mascotas..."; "Este método está enviando la información directamente al backend".
+   - Posible impacto: la clase mezcla lógica de controlador con llamadas directas a la API y usa un modelo `Pet` distinto de `PetData`. Esto complica el mantenimiento y puede provocar incoherencias en la aplicación.
+
+10. **CommonBase**
+    - Archivo: `lib/utils/common_base.dart`
+    - Línea: 339
+    - Comentario: "toLocal() Removed for UTC Time".
+    - Posible impacto: los tiempos pueden no ajustarse a la zona horaria correcta. Revisar si es necesario aplicar `toLocal()` al parsear fechas.
+
+11. **DateTimeExt**
+    - Archivo: `lib/utils/date_time_ext.dart`
+    - Línea: 7
+    - Comentario: "Cambiar esta extensión por un helper".
+    - Posible impacto: se plantea mover esta lógica a otra clase; no es un error pero se sugiere unificar la utilería de fechas.
+
+## Duplicidad de modelos `Pet`
+
+Se detectaron tres clases con el nombre `Pet`:
+
+- `lib/modules/integracion/model/mascotas/mascotas_model.dart`
+- `lib/modules/integracion/model/mascota/macotas_model.dart`
+- `lib/models/pet_model.dart`
+
+La clase `PetControllerv2` utiliza la definida en `mascotas_model.dart`, mientras que en el resto de la aplicación se maneja principalmente `PetData` (`lib/models/pet_data.dart`). Tener varias definiciones para la misma entidad complica la conversión de datos y puede producir errores al mapear campos o al serializar/deserializar información.
+
+En particular, el archivo `macotas_model.dart` (nótese el nombre) no parece estar referenciado en ninguna parte del código, por lo que podría tratarse de código muerto. Además, `PetData` es la estructura que utiliza el repositorio oficial (`PetsRepository`) y las vistas principales, por lo que mantener otra clase `Pet` en el controlador `PetControllerv2` genera redundancia y riesgo de inconsistencia.
+
+## Conclusiones
+
+- Es recomendable unificar la estructura de datos de las mascotas usando `PetData` y eliminar modelos duplicados o sin uso.
+- `PetControllerv2` debería delegar la lógica de red al `PetsRepository` para mantener un flujo único de datos.
+- Se sugiere revisar cada TODO y decidir si debe implementarse o eliminarse. Varios de ellos son restos de plantillas (`implement build`) o comentarios de refactorización pendientes.
+

--- a/.tasks/_taks.md
+++ b/.tasks/_taks.md
@@ -1,0 +1,12 @@
+- [ ] Revisar método "addPetDetailsApi" - pet_service_unused.md
+- [ ] Añadir soporte de archivos en PetsRepository - pets_repo_anexar_archivos.md
+- [ ] Limpiar TODO de plantillas - remover_todos_build.md
+- [ ] Verificar cierre de modales en ProfilePetController - profile_pet_modales.md
+- [ ] Revisar dependencia de PetControllerv2 en PetPassportForm - petpassportform_refactor.md
+- [ ] Validar formato de fecha en CursoVideo - curso_video_fecha.md
+- [ ] Simplificar paso de datos en Pacientes - pacientes_inyeccion_id.md
+- [ ] Implementar onInit en HistorialClinicoController - historial_clinico_oninit.md
+- [ ] Refactorizar PetControllerv2 - refactor_petcontrollerv2.md
+- [ ] Revisar conversión de fecha en CommonBase - common_base_tz.md
+- [ ] Migrar DateTimeExt a un helper - datetimeext_helper.md
+- [ ] Unificar modelos Pet - unificar_modelos_pet.md

--- a/.tasks/common_base_tz.md
+++ b/.tasks/common_base_tz.md
@@ -1,0 +1,10 @@
+# Revisar conversión de fecha en CommonBase
+
+En `lib/utils/common_base.dart` se comenta `toLocal()` (línea 339). Esto podría afectar la zona horaria.
+
+## Objetivo
+Evaluar si se debe aplicar `toLocal()` al parsear fechas o documentar claramente la decisión de mantener UTC.
+
+## Criterios de finalización
+- Determinación explícita sobre el uso de UTC vs zona local.
+- Código y comentarios actualizados.

--- a/.tasks/curso_video_fecha.md
+++ b/.tasks/curso_video_fecha.md
@@ -1,0 +1,10 @@
+# Validar formato de fecha en CursoVideo
+
+En `lib/modules/home/screens/explore/show/curso_video.dart` hay un TODO (línea 125) para verificar el formato de `dateCreated`.
+
+## Objetivo
+Asegurar que `DateHelper.formatUiDateLongFromString` maneje correctamente la cadena recibida o aplicar una validación previa.
+
+## Criterios de finalización
+- Manejo seguro de formatos inválidos sin romper la vista.
+- Pruebas que cubran distintos formatos de fecha.

--- a/.tasks/datetimeext_helper.md
+++ b/.tasks/datetimeext_helper.md
@@ -1,0 +1,11 @@
+# Migrar DateTimeExt a un helper
+
+El archivo `lib/utils/date_time_ext.dart` contiene la extensión `DateTimeExt` con un TODO en la línea 7.
+
+## Objetivo
+Mover la funcionalidad de formato de fechas a una clase helper o utilería centralizada.
+
+## Criterios de finalización
+- Nueva implementación en un helper reutilizable.
+- Archivo actualizado o eliminado según corresponda.
+- Pruebas que validen el formato de fechas.

--- a/.tasks/historial_clinico_oninit.md
+++ b/.tasks/historial_clinico_oninit.md
@@ -1,0 +1,10 @@
+# Implementar onInit en HistorialClinicoController
+
+En `lib/modules/integracion/controller/historial_clinico/historial_clinico_controller.dart` hay un TODO en la línea 29.
+
+## Objetivo
+Agregar la carga inicial de datos o lógica necesaria dentro de `onInit`.
+
+## Criterios de finalización
+- Definir claramente qué debe ocurrir en `onInit` y aplicarlo.
+- Sin TODOs pendientes en el archivo.

--- a/.tasks/pacientes_inyeccion_id.md
+++ b/.tasks/pacientes_inyeccion_id.md
@@ -1,0 +1,11 @@
+# Simplificar paso de datos en Pacientes
+
+La vista `lib/modules/dashboard/screens/pacientes.dart` contiene un TODO (línea 100) para reemplazar la inyección completa de `PetData`.
+
+## Objetivo
+Modificar la navegación para enviar solo el `id` de la mascota y cargar los datos en la pantalla de destino.
+
+## Criterios de finalización
+- Ajustar la ruta `Routes.PROFILEPET` para recibir únicamente el identificador.
+- Actualizar las dependencias de la vista receptora.
+- Eliminar el comentario TODO.

--- a/.tasks/pet_service_unused.md
+++ b/.tasks/pet_service_unused.md
@@ -1,0 +1,14 @@
+# Revisar método "addPetDetailsApi"
+
+El archivo `lib/services/pet_service_apis.dart` contiene un método marcado como sin uso.
+
+- Ubicación: línea 24.
+- Comentario: "Este método no se está utilizando".
+
+## Objetivo
+Determinar si se debe eliminar o integrar `addPetDetailsApi` al flujo actual de servicios.
+
+## Criterios de finalización
+- Definir si el método es necesario. Si no, eliminarlo.
+- En caso de usarlo, actualizar la documentación y referencias.
+- Todo el proyecto compila y las pruebas pasan.

--- a/.tasks/petpassportform_refactor.md
+++ b/.tasks/petpassportform_refactor.md
@@ -1,0 +1,10 @@
+# Revisar dependencia de PetControllerv2 en PetPassportForm
+
+El formulario `lib/modules/profile_pet/screens/pet_passport_form.dart` hace referencia a `PetControllerv2` con un TODO en la línea 32.
+
+## Objetivo
+Determinar si es necesario usar `PetControllerv2` o si se debe reemplazar por una solución basada en `PetsRepository`.
+
+## Criterios de finalización
+- Definir y documentar el controlador adecuado para el formulario.
+- Eliminar o actualizar el comentario TODO.

--- a/.tasks/pets_repo_anexar_archivos.md
+++ b/.tasks/pets_repo_anexar_archivos.md
@@ -1,0 +1,14 @@
+# Añadir soporte de archivos en PetsRepository
+
+El repositorio `lib/repositories/pets_repository.dart` necesita anexar archivos al crear mascotas.
+
+- Ubicación aproximada: línea 16.
+- Relacionado con el método `addPetDetailsApi` de `PetServiceApis`.
+
+## Objetivo
+Implementar la lógica para adjuntar imágenes u otros archivos desde el repositorio y delegar la llamada al servicio.
+
+## Criterios de finalización
+- Método implementado y utilizado en la creación de mascotas.
+- Documentar el uso correcto.
+- Compilación y pruebas exitosas.

--- a/.tasks/profile_pet_modales.md
+++ b/.tasks/profile_pet_modales.md
@@ -1,0 +1,11 @@
+# Verificar cierre de modales en ProfilePetController
+
+El controlador `lib/modules/profile_pet/controllers/profile_pet_controller.dart` contiene un TODO en la línea 167 sobre cuántos modales están abiertos.
+
+## Objetivo
+Asegurar que `Get.close(3)` corresponde realmente a la cantidad de diálogos mostrados al eliminar una mascota.
+
+## Criterios de finalización
+- Validar o ajustar el número de cierres necesarios.
+- Evitar cierres inesperados de pantallas.
+- Pruebas manuales o unitarias que confirmen el comportamiento.

--- a/.tasks/refactor_petcontrollerv2.md
+++ b/.tasks/refactor_petcontrollerv2.md
@@ -1,0 +1,12 @@
+# Refactorizar PetControllerv2
+
+El controlador `lib/modules/integracion/controller/mascotas/mascotas_controller.dart` incluye varios TODO (líneas 16, 35 y 120) que advierten sobre diseño y llamadas directas a la API.
+
+## Objetivo
+- Unificar el modelo utilizado (`PetData` en lugar de modelos alternos).
+- Delegar las peticiones de red al `PetsRepository`.
+- Revisar la lógica duplicada de `fetchPets`.
+
+## Criterios de finalización
+- Controlador simplificado y sin TODOs.
+- Pruebas o revisiones que demuestren la correcta integración con `PetsRepository`.

--- a/.tasks/remover_todos_build.md
+++ b/.tasks/remover_todos_build.md
@@ -1,0 +1,12 @@
+# Limpiar TODO de plantillas
+
+En los widgets `Cursos` y `BanerComentarios` existen comentarios `// TODO: implement build`.
+
+- Archivos: `lib/modules/apprenticeship/component/cursos.dart` (línea 22) y `lib/modules/components/baner_comentarios.dart` (línea 111).
+
+## Objetivo
+Eliminar estos comentarios o implementar el código faltante si aplica.
+
+## Criterios de finalización
+- Los widgets no muestran TODO pendientes en su método `build`.
+- El proyecto sigue compilando sin advertencias relacionadas.

--- a/.tasks/unificar_modelos_pet.md
+++ b/.tasks/unificar_modelos_pet.md
@@ -1,0 +1,16 @@
+# Unificar modelos `Pet`
+
+Se detectaron múltiples definiciones de la clase `Pet`:
+- `lib/modules/integracion/model/mascotas/mascotas_model.dart`
+- `lib/modules/integracion/model/mascota/macotas_model.dart`
+- `lib/models/pet_model.dart`
+
+Además, la aplicación usa `PetData` como modelo principal.
+
+## Objetivo
+Eliminar duplicaciones y adoptar una única representación para las mascotas, preferiblemente `PetData`.
+
+## Criterios de finalización
+- Identificar cuál(es) modelos se usan realmente y depurar los sobrantes.
+- Actualizar controladores y vistas que dependan de las clases eliminadas.
+- Compilación y pruebas correctas.


### PR DESCRIPTION
## Summary
- create `.tasks` directory with individual task files covering each TODO noted in the report
- track progress in `.tasks/_taks.md`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6863045da9f4832db1f0a31f7e0e3a37