### PR TITLE
feat: bloquea toques repetidos en más botones

### DIFF
--- a/lib/modules/auth/sign_in/screens/signin_screen.dart
+++ b/lib/modules/auth/sign_in/screens/signin_screen.dart
@@ -77,19 +77,19 @@ class SignInScreen extends StatelessWidget {
                             ),
                             Container(
                               margin: const EdgeInsets.only(top: 16),
-                              child: ButtonDefaultWidget(
-                                title: 'Inicia Sesión',
-                                callback: () {
-                                  // Get.to(Inicio());
-                                  print('login');
-                                  if (_signInformKey.currentState!.validate()) {
-                                    _signInformKey.currentState!.save();
-                                    signInController.saveForm();
-                                    // print(signInController);
-                                    // Get.toNamed(Routes.HOME);
-                                  }
-                                },
-                                showDecoration: true,
+                              child: Obx(
+                                () => ButtonDefaultWidget(
+                                  title: 'Inicia Sesión',
+                                  isLoading: signInController.isLoading.value,
+                                  callback: () async {
+                                    print('login');
+                                    if (_signInformKey.currentState!.validate()) {
+                                      _signInformKey.currentState!.save();
+                                      await signInController.saveForm();
+                                    }
+                                  },
+                                  showDecoration: true,
+                                ),
                               ),
                             ),
                             Row(
@@ -121,30 +121,40 @@ class SignInScreen extends StatelessWidget {
                     // Google Sign-In (Android only)
                     if (Platform.isAndroid) ...[
                       const SizedBox(height: 16),
-                      SizedBox(
-                        width: double.infinity,
-                        height: 54,
-                        child: ElevatedButton.icon(
-                          style: ElevatedButton.styleFrom(
-                            backgroundColor: Colors.white,
-                            foregroundColor: Colors.black,
-                            side: const BorderSide(color: Styles.greyDivider),
-                            shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(16)),
-                          ),
-                          icon: Image.asset(
-                            Assets.imagesGoogleLogo,
-                            width: 24,
-                            height: 24,
-                          ),
-                          label: const Text(
-                            'Continuar con Google',
-                            style: TextStyle(
-                              fontSize: 16,
-                              fontWeight: FontWeight.w500,
+                      Obx(
+                        () => SizedBox(
+                          width: double.infinity,
+                          height: 54,
+                          child: ElevatedButton.icon(
+                            style: ElevatedButton.styleFrom(
+                              backgroundColor: Colors.white,
+                              foregroundColor: Colors.black,
+                              side: const BorderSide(color: Styles.greyDivider),
+                              shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(16)),
                             ),
+                            icon: Image.asset(
+                              Assets.imagesGoogleLogo,
+                              width: 24,
+                              height: 24,
+                            ),
+                            label: signInController.isLoading.value
+                                ? const SizedBox(
+                                    width: 20,
+                                    height: 20,
+                                    child: CircularProgressIndicator(strokeWidth: 2),
+                                  )
+                                : const Text(
+                                    'Continuar con Google',
+                                    style: TextStyle(
+                                      fontSize: 16,
+                                      fontWeight: FontWeight.w500,
+                                    ),
+                                  ),
+                            onPressed: signInController.isLoading.value
+                                ? null
+                                : () => signInController.googleSignIn(context),
                           ),
-                          onPressed: () => signInController.googleSignIn(context),
                         ),
                       ),
                     ],

--- a/lib/modules/components/baner_entrenamiento.dart
+++ b/lib/modules/components/baner_entrenamiento.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:pawlly/styles/recursos.dart';
 import 'package:pawlly/styles/styles.dart';
 
-class BanerEntrenamiento extends StatelessWidget {
+class BanerEntrenamiento extends StatefulWidget {
   BanerEntrenamiento({
     super.key,
     required this.imagen,
@@ -19,6 +19,19 @@ class BanerEntrenamiento extends StatelessWidget {
   final double normalizedProgress;
   final bool ishorizontal;
   final void Function()? callback;
+
+  @override
+  State<BanerEntrenamiento> createState() => _BanerEntrenamientoState();
+}
+
+class _BanerEntrenamientoState extends State<BanerEntrenamiento> {
+  bool _isLoading = false;
+
+  void _handlePressed() {
+    if (_isLoading) return;
+    setState(() => _isLoading = true);
+    widget.callback?.call();
+  }
 
   String dificultadValue(String dificultad) {
     switch (dificultad) {
@@ -39,7 +52,7 @@ class BanerEntrenamiento extends StatelessWidget {
     // Ajuste dinámico del ancho de la imagen basado en el ancho de la pantalla
     // para diferentes orientaciones (horizontal o vertical)
     final double imageWidth =
-        ishorizontal ? screenWidth * 0.30 : screenWidth * 0.35;
+        widget.ishorizontal ? screenWidth * 0.30 : screenWidth * 0.35;
     final double imageHeight =
         imageWidth * (122 / 131); // Mantiene la proporción de la imagen
 
@@ -86,7 +99,7 @@ class BanerEntrenamiento extends StatelessWidget {
               borderRadius: BorderRadius.circular(7.72),
               // Widget para mostrar la imagen desde la red
               child: Image.network(
-                imagen,
+                widget.imagen,
                 fit: BoxFit
                     .cover, // Asegura que la imagen cubra todo el contenedor sin deformarse
                 // Widget que muestra un indicador de progreso mientras se carga la imagen
@@ -127,7 +140,7 @@ class BanerEntrenamiento extends StatelessWidget {
                 children: [
                   // Dificultad del curso
                   Text(
-                    dificultadValue(dificultad ?? ''),
+                    dificultadValue(widget.dificultad ?? ''),
                     style: const TextStyle(
                       fontFamily: 'Lato',
                       fontSize:
@@ -140,7 +153,7 @@ class BanerEntrenamiento extends StatelessWidget {
                   // Nombre del curso, envuelto en un Flexible para permitir que se ajuste al espacio disponible
                   Flexible(
                     child: Text(
-                      nombre,
+                      widget.nombre,
                       maxLines: 2, // Limita el nombre a 2 líneas
                       overflow: TextOverflow
                           .ellipsis, // Muestra puntos suspensivos si el texto excede el límite
@@ -175,7 +188,7 @@ class BanerEntrenamiento extends StatelessWidget {
                         child: ClipRRect(
                           borderRadius: BorderRadius.circular(27.0),
                           child: LinearProgressIndicator(
-                            value: normalizedProgress,
+                            value: widget.normalizedProgress,
                             backgroundColor: const Color(0XFFECECEC),
                             color: Styles.iconColorBack,
                             minHeight:
@@ -186,7 +199,7 @@ class BanerEntrenamiento extends StatelessWidget {
                       ),
                       // Porcentaje de progreso
                       Text(
-                        '${(normalizedProgress * 100).toStringAsFixed(0)}%',
+                        '${(widget.normalizedProgress * 100).toStringAsFixed(0)}%',
                         style: const TextStyle(
                           fontFamily: 'Lato',
                           fontSize:
@@ -203,7 +216,7 @@ class BanerEntrenamiento extends StatelessWidget {
                   SizedBox(
                     height: 28, // Reduje la altura del botón
                     child: ElevatedButton(
-                      onPressed: callback,
+                      onPressed: _isLoading ? null : _handlePressed,
                       style: ElevatedButton.styleFrom(
                         backgroundColor: Styles.primaryColor,
                         padding: const EdgeInsets.symmetric(
@@ -213,21 +226,27 @@ class BanerEntrenamiento extends StatelessWidget {
                         ),
                         elevation: 0,
                       ),
-                      child: const Row(
+                      child: Row(
                         mainAxisAlignment: MainAxisAlignment.center,
                         crossAxisAlignment: CrossAxisAlignment.center,
                         // Texto del botón
                         children: [
-                          Text(
-                            'Seguir viendo',
-                            style: TextStyle(
-                              fontFamily: 'Lato',
-                              fontSize:
-                                  11, // Reduje el tamaño de fuente del botón
-                              fontWeight: FontWeight.w400,
-                              color: Color(0xffFFFFFF),
+                          if (_isLoading)
+                            const SizedBox(
+                              height: 12,
+                              width: 12,
+                              child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white),
+                            )
+                          else
+                            const Text(
+                              'Seguir viendo',
+                              style: TextStyle(
+                                fontFamily: 'Lato',
+                                fontSize: 11,
+                                fontWeight: FontWeight.w400,
+                                color: Color(0xffFFFFFF),
+                              ),
                             ),
-                          ),
                         ],
                       ),
                     ),

--- a/lib/modules/components/input_tag_wiget.dart
+++ b/lib/modules/components/input_tag_wiget.dart
@@ -40,108 +40,108 @@ class _TagInputWidgetState extends State<TagInputWidget> {
         .clear(); // Limpiamos el texto cada vez que abrimos el diálogo
 
     Get.dialog(
-      AlertDialog(
-        backgroundColor: Colors.white, // Fondo blanco
-        contentPadding: const EdgeInsets.all(20),
-        title: const Text(
-          'Nueva Tab',
-          textAlign: TextAlign.center,
-          style: const TextStyle(
-            fontSize: 28,
-            fontWeight: FontWeight.bold,
-            fontFamily: 'Lato',
-            color: const Color(0xFFFF4931),
-          ),
-        ),
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            TextFormField(
-              controller: _dialogController,
-              decoration: const InputDecoration(
-                labelText: 'Nombre de la Tab',
-                labelStyle: TextStyle(
-                  fontFamily: 'Lato',
-                  fontSize: 14,
-                  fontWeight: FontWeight.w400,
-                  color: Colors.black,
+      StatefulBuilder(
+        builder: (context, setStateDialog) {
+          bool isProcessing = false;
+          return AlertDialog(
+            backgroundColor: Colors.white,
+            contentPadding: const EdgeInsets.all(20),
+            title: const Text(
+              'Nueva Tab',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 28,
+                fontWeight: FontWeight.bold,
+                fontFamily: 'Lato',
+                color: Color(0xFFFF4931),
+              ),
+            ),
+            content: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                TextFormField(
+                  controller: _dialogController,
+                  decoration: const InputDecoration(
+                    labelText: 'Nombre de la Tab',
+                    labelStyle: TextStyle(
+                      fontFamily: 'Lato',
+                      fontSize: 14,
+                      fontWeight: FontWeight.w400,
+                      color: Colors.black,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            actions: [
+              TextButton(
+                onPressed: isProcessing ? null : () => Get.back(),
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Styles.primaryColor,
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 35,
+                    vertical: 8,
+                  ),
+                  elevation: 0,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  textStyle: const TextStyle(
+                    fontFamily: 'Lato',
+                    color: Colors.white,
+                    fontSize: 16,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+                child: const Text(
+                  'Cancelar',
+                  style: TextStyle(
+                    fontFamily: 'Lato',
+                    color: Colors.white,
+                    fontSize: 16,
+                    fontWeight: FontWeight.w500,
+                  ),
                 ),
               ),
-            ),
-          ],
-        ),
-        actions: [
-          TextButton(
-            onPressed: () {
-              // Cerramos el diálogo sin hacer nada
-              Get.back();
-            },
-            style: ElevatedButton.styleFrom(
-              backgroundColor: Styles.primaryColor,
-              padding: const EdgeInsets.symmetric(
-                horizontal: 35,
-                vertical: 8,
+              ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: const Color(0xFFFC9214),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 35,
+                    vertical: 8,
+                  ),
+                  elevation: 0,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                ),
+                onPressed: isProcessing
+                    ? null
+                    : () {
+                        final newTag = _dialogController.text.trim();
+                        if (newTag.isNotEmpty && !_tags.contains(newTag)) {
+                          final quotedTag = '"$newTag"';
+                          setState(() {
+                            _tags.add(quotedTag);
+                          });
+                          widget.onChanged?.call(_tags);
+                        }
+                        setStateDialog(() => isProcessing = true);
+                        Get.back();
+                      },
+                child: const Text(
+                  'Agregar',
+                  style: TextStyle(
+                    fontFamily: 'Lato',
+                    color: Colors.white,
+                    fontSize: 16,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
               ),
-              elevation: 0,
-              shape: RoundedRectangleBorder(
-                borderRadius:
-                    BorderRadius.circular(12), // Se agrega el borderRadius
-              ),
-              textStyle: const TextStyle(
-                fontFamily: 'Lato',
-                color: Colors.white,
-                fontSize: 16,
-                fontWeight: FontWeight.w500,
-              ),
-            ),
-            child: const Text(
-              'Cancelar',
-              style: const TextStyle(
-                fontFamily: 'Lato',
-                color: Colors.white,
-                fontSize: 16,
-                fontWeight: FontWeight.w500,
-              ),
-            ),
-          ),
-          ElevatedButton(
-            style: ElevatedButton.styleFrom(
-              backgroundColor: Color(0xFFFC9214),
-              padding: const EdgeInsets.symmetric(
-                horizontal: 35,
-                vertical: 8,
-              ),
-              elevation: 0,
-              shape: RoundedRectangleBorder(
-                borderRadius:
-                    BorderRadius.circular(12), // Se agrega el borderRadius
-              ),
-            ),
-            onPressed: () {
-              final newTag = _dialogController.text.trim();
-              if (newTag.isNotEmpty && !_tags.contains(newTag)) {
-                // Agrega el texto con comillas dobles.
-                final quotedTag = '"$newTag"';
-
-                setState(() {
-                  _tags.add(quotedTag);
-                });
-                widget.onChanged?.call(_tags);
-              }
-              // Cerramos el diálogo
-              Get.back();
-            },
-            child: const Text(
-              'Agregar',
-              style: const TextStyle(
-                fontFamily: 'Lato',
-                color: Colors.white,
-                fontSize: 16,
-                fontWeight: FontWeight.w500,
-              ),
-            ),
-          ),
-        ],
+            ],
+          );
+        },
       ),
       barrierDismissible: false,
     );

--- a/lib/modules/diario/diario.dart
+++ b/lib/modules/diario/diario.dart
@@ -91,9 +91,12 @@ class Diario extends StatelessWidget {
                             Expanded(
                               flex: 2,
                               child: ElevatedButton(
-                                  onPressed: () {
-                                    FiltrarActividad.show(
+                                  onPressed: () async {
+                                    if (historialClinicoController.isFiltering.value) return;
+                                    historialClinicoController.isFiltering.value = true;
+                                    await FiltrarActividad.show(
                                         context, historialClinicoController);
+                                    historialClinicoController.isFiltering.value = false;
                                   },
                                   style: ElevatedButton.styleFrom(
                                     elevation: 0,

--- a/lib/modules/home/screens/explore/training_programs.dart
+++ b/lib/modules/home/screens/explore/training_programs.dart
@@ -200,21 +200,22 @@ class TrainingPrograms extends StatelessWidget {
                               SizedBox(
                                 height: 30, // Reduje la altura del botón
                                 child: ElevatedButton(
-                                  onPressed: () {
-                                    // Navegar a detalles del curso
-                                    Get.to(() => CursosDetalles(
-                                          cursoId: "${course.id.toString()}",
-                                        ));
-                                    // Navegar a video del curso
-                                    var video = cursosController.findVideoById(
-                                      courseId: course.id,
-                                      videoId: course.id.toString(),
-                                    );
+                                  onPressed: cursosController.isNavigating.value
+                                      ? null
+                                      : () {
+                                          cursosController.isNavigating.value = true;
+                                          Get.to(() => CursosDetalles(
+                                                cursoId: "${course.id.toString()}",
+                                              ));
+                                          var video = cursosController.findVideoById(
+                                            courseId: course.id,
+                                            videoId: course.id.toString(),
+                                          );
 
-                                    Get.to(() => CursosDetalles(
-                                          cursoId: course.id.toString(),
-                                        ));
-                                  },
+                                          Get.to(() => CursosDetalles(
+                                                cursoId: course.id.toString(),
+                                              ));
+                                        },
                                   style: ElevatedButton.styleFrom(
                                     backgroundColor: Styles.primaryColor,
                                     padding: const EdgeInsets.symmetric(

--- a/lib/modules/home/screens/widgets/filtrar_actividad.dart
+++ b/lib/modules/home/screens/widgets/filtrar_actividad.dart
@@ -10,8 +10,9 @@ class FiltrarActividad extends StatefulWidget {
 
   const FiltrarActividad({super.key, required this.controller});
 
-  static void show(BuildContext context, PetActivityController controller) {
-    showDialog(
+  static Future<void> show(
+      BuildContext context, PetActivityController controller) {
+    return showDialog(
       context: context,
       builder: (context) {
         return FiltrarActividad(controller: controller);
@@ -38,6 +39,7 @@ class _FiltrarActividadState extends State<FiltrarActividad> {
 
   /// Para "Ver más" en Categoría
   bool showMoreCategories = false;
+  bool _isApplying = false;
 
   /// Categoría seleccionada
   String? selectedCategory;
@@ -282,26 +284,35 @@ class _FiltrarActividadState extends State<FiltrarActividad> {
                       ),
                       padding: const EdgeInsets.symmetric(vertical: 14),
                     ),
-                    onPressed: () {
-                      // 1. Llamamos a applyFilters en el controlador
-                      widget.controller.applyFilters(
-                        categoryName: selectedCategory,
-                        sortType: selectedSorting,
-                        dateLabel: selectedDateChip,
-                      );
-
-                      // 2. Cerrar el diálogo
-                      Navigator.of(context).pop();
-                    },
-                    child: const Text(
-                      'Filtrar',
-                      style: TextStyle(
-                        color: Colors.white,
-                        fontSize: 16,
-                        fontFamily: 'Lato',
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
+                    onPressed: _isApplying
+                        ? null
+                        : () {
+                            setState(() => _isApplying = true);
+                            widget.controller.applyFilters(
+                              categoryName: selectedCategory,
+                              sortType: selectedSorting,
+                              dateLabel: selectedDateChip,
+                            );
+                            Navigator.of(context).pop();
+                          },
+                    child: _isApplying
+                        ? const SizedBox(
+                            height: 20,
+                            width: 20,
+                            child: CircularProgressIndicator(
+                              strokeWidth: 2,
+                              color: Colors.white,
+                            ),
+                          )
+                        : const Text(
+                            'Filtrar',
+                            style: TextStyle(
+                              color: Colors.white,
+                              fontSize: 16,
+                              fontFamily: 'Lato',
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
                   ),
                 ),
               ),

--- a/lib/modules/integracion/controller/cursos/cursos_controller.dart
+++ b/lib/modules/integracion/controller/cursos/cursos_controller.dart
@@ -12,6 +12,7 @@ class CourseController extends GetxController {
   var courses = <Course>[].obs;
   var mycourses = <Course>[].obs;
   var isLoading = false.obs;
+  var isNavigating = false.obs;
   var url = "$DOMAIN_URL/api/course-platform";
   var filteredCourses = <Course>[].obs;
   get jsonData => null;

--- a/lib/modules/integracion/controller/diario/activida_mascota_controller.dart
+++ b/lib/modules/integracion/controller/diario/activida_mascota_controller.dart
@@ -15,6 +15,7 @@ import 'package:pawlly/services/auth_service_apis.dart';
 class PetActivityController extends GetxController {
   final HomeController homeController = Get.put(HomeController());
   var isLoading = false.obs;
+  var isFiltering = false.obs;
   var activities = <PetActivity>[].obs;
   var filteredActivities = <PetActivity>[].obs;
   var activitiesOne = Rxn<PetActivity>(); // Observable para almacenar una sola actividad

--- a/lib/modules/integracion/controller/historial_clinico/historial_clinico_controller.dart
+++ b/lib/modules/integracion/controller/historial_clinico/historial_clinico_controller.dart
@@ -22,6 +22,7 @@ class HistorialClinicoController extends GetxController {
   var selectedSortOption = "".obs; // Opción de orden seleccionada
   var isEditing = false.obs;
   var isLoading = false.obs;
+  var isFilterDialogOpen = false.obs;
   var isSuccess = false.obs;
 
   @override

--- a/lib/modules/profile_pet/controllers/pet_owner_controller.dart
+++ b/lib/modules/profile_pet/controllers/pet_owner_controller.dart
@@ -7,6 +7,7 @@ import 'package:pawlly/services/auth_service_apis.dart';
 
 class PetOwnerController extends GetxController {
   var associatedPersons = <Map<String, dynamic>>[].obs; // Lista observable
+  var isAddingPerson = false.obs;
 
   Future<void> fetchOwnersList(int petId) async {
     final url = Uri.parse('${BASE_URL}pets/$petId/owners');

--- a/lib/modules/profile_pet/controllers/profile_pet_controller.dart
+++ b/lib/modules/profile_pet/controllers/profile_pet_controller.dart
@@ -35,6 +35,7 @@ class ProfilePetController extends GetxController {
   var profileImagePath = ''.obs;
   var isPickerActive = false.obs;
   var medicalHistory = [].obs;
+  var isOpeningPassport = false.obs;
 
   var userTypeCont = TextEditingController().obs;
   var emailController = TextEditingController().obs;

--- a/lib/modules/profile_pet/screens/widget/information_tab.dart
+++ b/lib/modules/profile_pet/screens/widget/information_tab.dart
@@ -89,16 +89,20 @@ class InformationTab extends StatelessWidget {
               Center(
                 child: SizedBox(
                   height: 54,
-                  child: ButtonDefaultWidget(
-                    iconAfterText: false,
-                    title: 'Pasaporte',
-                    svgIconPath: 'assets/icons/svg/mdi_passport.svg',
-                    callback: () {
-                      Get.to(
-                        PetPassportView(),
-                      );
-                    },
-                  ),
+                  child: Obx(() => ButtonDefaultWidget(
+                        iconAfterText: false,
+                        title: 'Pasaporte',
+                        svgIconPath: 'assets/icons/svg/mdi_passport.svg',
+                        isLoading: controller.isOpeningPassport.value,
+                        callback: () async {
+                          if (controller.isOpeningPassport.value) return;
+                          controller.isOpeningPassport.value = true;
+                          await Get.to(
+                            PetPassportView(),
+                          );
+                          controller.isOpeningPassport.value = false;
+                        },
+                      )),
                 ),
               ),
               SizedBox(height: margen),
@@ -392,33 +396,46 @@ class InformationTab extends StatelessWidget {
                   SizedBox(
                     width: 44, // Ancho fijo
                     height: 44, // Alto fijo
-                    child: ElevatedButton(
-                      onPressed: () {
-                        showModalBottomSheet(
-                          context: context,
-                          isScrollControlled: true,
-                          shape: const RoundedRectangleBorder(
-                            borderRadius: BorderRadius.vertical(
-                                top: Radius.circular(20)),
+                    child: Obx(() => ElevatedButton(
+                          onPressed: petcontroller.isAddingPerson.value
+                              ? null
+                              : () async {
+                                  petcontroller.isAddingPerson.value = true;
+                                  await showModalBottomSheet(
+                                    context: context,
+                                    isScrollControlled: true,
+                                    shape: const RoundedRectangleBorder(
+                                      borderRadius: BorderRadius.vertical(
+                                          top: Radius.circular(20)),
+                                    ),
+                                    builder: (context) {
+                                      return AssociatedPersonsModal(
+                                          controller: controller);
+                                    },
+                                  );
+                                  petcontroller.isAddingPerson.value = false;
+                                },
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: const Color(0xFFFC9214),
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(10),
+                            ),
+                            padding: EdgeInsets.zero,
+                            shadowColor: Colors.transparent,
+                            elevation: 0,
                           ),
-                          builder: (context) {
-                            return AssociatedPersonsModal(
-                                controller: controller);
-                          },
-                        );
-                      },
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: const Color(0xFFFC9214),
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(10),
-                        ),
-                        padding: EdgeInsets.zero,
-                        shadowColor: Colors.transparent, // Elimina la sombra
-                        elevation: 0, // Evita cualquier sombra residual
-                      ),
-                      child: const Icon(Icons.add,
-                          color: Colors.white, size: 24), // Centrado
-                    ),
+                          child: petcontroller.isAddingPerson.value
+                              ? const SizedBox(
+                                  height: 20,
+                                  width: 20,
+                                  child: CircularProgressIndicator(
+                                    strokeWidth: 2,
+                                    color: Colors.white,
+                                  ),
+                                )
+                              : const Icon(Icons.add,
+                                  color: Colors.white, size: 24),
+                        )),
                   ),
                 ],
               ),

--- a/lib/modules/profile_pet/screens/widget/medical_histor_tab.dart
+++ b/lib/modules/profile_pet/screens/widget/medical_histor_tab.dart
@@ -122,8 +122,11 @@ class MedicalHistoryTab extends StatelessWidget {
                 ),
                 const SizedBox(width: 8),
                 ElevatedButton(
-                  onPressed: () {
-                    FilterDialog.show(context, medicalHistoryController);
+                  onPressed: () async {
+                    if (medicalHistoryController.isFilterDialogOpen.value) return;
+                    medicalHistoryController.isFilterDialogOpen.value = true;
+                    await FilterDialog.show(context, medicalHistoryController);
+                    medicalHistoryController.isFilterDialogOpen.value = false;
                   },
                   style: ElevatedButton.styleFrom(
                     padding: EdgeInsets.zero,

--- a/lib/modules/profile_pet/screens/widget/show_filter_dialog.dart
+++ b/lib/modules/profile_pet/screens/widget/show_filter_dialog.dart
@@ -3,14 +3,20 @@ import 'package:get/get.dart';
 import 'package:pawlly/components/button_default_widget.dart';
 import 'package:pawlly/modules/integracion/controller/historial_clinico/historial_clinico_controller.dart';
 
-class FilterDialog extends StatelessWidget {
+class FilterDialog extends StatefulWidget {
   final HistorialClinicoController controller;
 
   const FilterDialog({super.key, required this.controller});
 
   @override
+  State<FilterDialog> createState() => _FilterDialogState();
+}
+
+class _FilterDialogState extends State<FilterDialog> {
+  bool _isApplying = false;
+
+  @override
   Widget build(BuildContext context) {
-    // Variables para almacenar temporalmente los valores del rango de fechas
     final startDateController = TextEditingController();
     final endDateController = TextEditingController();
     final reportNameController = TextEditingController();
@@ -41,13 +47,13 @@ class FilterDialog extends StatelessWidget {
             const SizedBox(height: 8),
             Obx(
               () => Column(
-                children: controller.sortOptions.map((option) {
+                children: widget.controller.sortOptions.map((option) {
                   return Row(
                     children: [
                       Checkbox(
-                        value: controller.selectedSortOption.value == option,
+                        value: widget.controller.selectedSortOption.value == option,
                         onChanged: (bool? value) {
-                          controller.selectSortOption(option);
+                          widget.controller.selectSortOption(option);
                         },
                         shape: RoundedRectangleBorder(
                           borderRadius: BorderRadius.circular(2),
@@ -76,13 +82,13 @@ class FilterDialog extends StatelessWidget {
             const SizedBox(height: 8),
             Obx(
               () => Column(
-                children: controller.categories.map((category) {
+                children: widget.controller.categories.map((category) {
                   return Row(
                     children: [
                       Checkbox(
-                        value: controller.selectedCategory.value == category,
+                        value: widget.controller.selectedCategory.value == category,
                         onChanged: (bool? value) {
-                          controller.selectCategory(category);
+                          widget.controller.selectCategory(category);
                         },
                         shape: RoundedRectangleBorder(
                           borderRadius: BorderRadius.circular(2),
@@ -106,36 +112,39 @@ class FilterDialog extends StatelessWidget {
       actions: [
         ButtonDefaultWidget(
           title: 'Filtrar',
+          isLoading: _isApplying,
           callback: () {
-            // Extraer valores ingresados
+            if (_isApplying) return;
+            setState(() => _isApplying = true);
             final reportName = reportNameController.text;
             final startDate = startDateController.text;
             final endDate = endDateController.text;
 
-            // Aplicar los filtros en el controlador
-            controller.filterHistorialClinico(
+            widget.controller.filterHistorialClinico(
               reportName: reportName.isNotEmpty ? reportName : null,
               startDate: startDate.isNotEmpty ? startDate : null,
               endDate: endDate.isNotEmpty ? endDate : null,
-              category: controller.selectedCategory.value,
+              category: widget.controller.selectedCategory.value,
             );
 
-            Navigator.of(context).pop(); // Cerrar el diálogo
+            Navigator.of(context).pop();
           },
         ),
         TextButton(
-          onPressed: () {
-            Navigator.of(context).pop(); // Cerrar el diálogo sin aplicar
-          },
+          onPressed: _isApplying
+              ? null
+              : () {
+                  Navigator.of(context).pop();
+                },
           child: const Text('Cancelar'),
         ),
       ],
     );
   }
 
-  static void show(
+  static Future<void> show(
       BuildContext context, HistorialClinicoController controller) {
-    showDialog(
+    return showDialog(
       context: context,
       builder: (context) {
         return FilterDialog(controller: controller);

--- a/lib/modules/welcome/screens/welcome_screen.dart
+++ b/lib/modules/welcome/screens/welcome_screen.dart
@@ -32,6 +32,8 @@ class WelcomeScreen extends GetView<WelcomeController> {
     ),
   ];
 
+  final RxBool _isNavigating = false.obs;
+
   @override
   Widget build(BuildContext context) {
     final width = MediaQuery.sizeOf(context).width;
@@ -83,14 +85,18 @@ class WelcomeScreen extends GetView<WelcomeController> {
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: [
-                        ButtonDefaultWidget(
-                          title: "Inicia Sesión",
-                          callback: () {
-                            Get.toNamed(
-                              'signin',
-                            );
-                          },
-                          showDecoration: true,
+                        Obx(
+                          () => ButtonDefaultWidget(
+                            title: "Inicia Sesión",
+                            isLoading: _isNavigating.value,
+                            callback: () async {
+                              if (_isNavigating.value) return;
+                              _isNavigating.value = true;
+                              await Get.toNamed('signin');
+                              _isNavigating.value = false;
+                            },
+                            showDecoration: true,
+                          ),
                         ),
                         const SizedBox(
                           height: 16,


### PR DESCRIPTION
## Resumen
- Desactiva acciones múltiples en banner de entrenamiento y diálogo de tags
- Bloquea filtros y navegaciones duplicadas en Diario y Programas de entrenamiento
- Evita toques repetidos en botones de pasaporte y personas asociadas de la mascota

## Pruebas
- `flutter test` *(falla: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689638326630832aa4b71d999c7b5fe2